### PR TITLE
quickselling should be done on item's id not resourceId

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ Usage
     >>> fut.sendToClub(trade_id)       # add card to club
     >>> fut.tradepileDelete(trade_id)  # removes item from tradepile
     >>> fut.watchlistDelete(trade_id)  # removes item from watch list
+    >>> fut.quickSell(item_id)         # quicksell item
 
     >>> fut.relist()  # relist all expired cards in tradepile
 

--- a/fut14/core.py
+++ b/fut14/core.py
@@ -356,9 +356,9 @@ class Core(object):
         rc = self.__post__(self.urls['fut']['SearchAuctionsListItem'], data=json.dumps(data))
         return rc['id']
 
-    def quickSell(self, resource_id):
+    def quickSell(self, item_id):
         """Quick sell."""
-        params = {'resourceId': resource_id}
+        params = {'itemIds': item_id}
         self.__delete__(self.urls['fut']['Item'], params=params)  # returns nothing
         return True
 


### PR DESCRIPTION
Quickselling with the item's id rather than resourceId makes more sense. I couldn't get it working with resourceIds anyway.
