### PR TITLE
Get broke the login flow, revert

### DIFF
--- a/fut/core.py
+++ b/fut/core.py
@@ -397,7 +397,7 @@ class Core(object):
                 raise FutError(reason=failedReason)
 
             if 'var redirectUri' in rc.text:
-                rc = self.r.get(rc.url, {'_eventId': 'end'})  # initref param was missing here
+                rc = self.r.post(rc.url, {'_eventId': 'end'})  # initref param was missing here
 
             '''  # pops out only on first launch
             if 'FIFA Ultimate Team</strong> needs to update your Account to help protect your gameplay experience.' in rc:  # request email/sms code


### PR DESCRIPTION
Login pipeline broke after changing this post to add. 

The first issue was that python complained about get method taking 2 params and 3 given, I had to change the passed param as cookies = {'_eventId': 'end'}
Even after that some other things didn't work so I'm just reverting the get change. If anything else we can test it better and re-release. 

We have to cut a new release because our 0.3.1 seems to be broken as is.
