### PR TITLE
Fix query params 'league' and 'nation' used in Core.club()

### DIFF
--- a/fut/core.py
+++ b/fut/core.py
@@ -1151,7 +1151,7 @@ class Core(object):
         if assetId:
             params['maskedDefId'] = assetId
         if league:
-            params['leag'] = league
+            params['league'] = league
         if club:
             params['team'] = club
         if position:
@@ -1159,7 +1159,7 @@ class Core(object):
         if zone:
             params['zone'] = zone
         if nationality:
-            params['nat'] = nationality
+            params['nation'] = nationality
         if rare:
             params['rare'] = 'SP'
         if playStyle:


### PR DESCRIPTION
This PR fixes query param names used in `Core.club()` that don't work for FUT 19. An example API call captured in Chrome looks like this:

https://utas.external.s2.fut.ea.com/ut/game/fifa19/club?sort=asc&type=player&level=bronze&team=650&league=10&nation=34&position=RB&start=0&count=91&_=1548437016376

Note the correct `league` and `nation` params in the above URL.